### PR TITLE
[HSRN VIP] format in influxdb line protocol and annotate traffic with namespace and pod info

### DIFF
--- a/k8s-traffic-logger.py
+++ b/k8s-traffic-logger.py
@@ -213,27 +213,21 @@ while not exiting:
 
     # output
     ipv4_datapoints = ""
-    for k, (send_bytes, recv_bytes) in sorted(ipv4_throughput.items(),
+    for local_address, (send_bytes, recv_bytes) in sorted(ipv4_throughput.items(),
                                               key=lambda kv: sum(kv[1]),
                                               reverse=True):
 
-        ipv4_datapoints += "{measurement},{tag1}={val1},{tag2}={val2},{tag3}={val3},{tag4}={val4},{tag5}={val5} {field1}={field_val1},{field2}={field_val2} {timestamp}".format(
+        ipv4_datapoints += "{measurement},hostname={hostname},ip_version={ip_version},local_address={local_address},namespace={namespace},pod={pod} sent_bytes={send_bytes},received_bytes={recv_bytes} {timestamp}".format(
             measurement=MEASUREMENT,
-            tag1="HOSTNAME",
-            val1=hostname,
-            tag2="IPv",
-            val2="4",
-            tag3="LADDR",
-            val3=k,
-            tag4="NAMESPACE",
-            val4=all_pod_metadata.get(k,["NA","NA"])[0],
-            tag5="POD",
-            val5=all_pod_metadata.get(k,["NA","NA"])[1],
-            field1=TX,
-            field_val1=int(send_bytes),
-            field2=RX,
-            field_val2=int(recv_bytes),
-            timestamp=int(float(time())*10**9))
+            hostname=hostname,
+            ip_version="4",
+            local_address=local_address,
+            namespace=all_pod_metadata.get(local_address, ["NA", "NA"])[0],
+            pod=all_pod_metadata.get(local_address, ["NA", "NA"])[1],
+            send_bytes=int(send_bytes),
+            recv_bytes=int(recv_bytes),
+            timestamp=int(float(time()) * 10**9),
+        )
         ipv4_datapoints += "\n"
 
     response = requests.post(ENDPOINT, headers=HEADERS, data=ipv4_datapoints)
@@ -259,27 +253,21 @@ while not exiting:
 
     # output
     ipv6_datapoints = ""
-    for k, (send_bytes, recv_bytes) in sorted(ipv6_throughput.items(),
+    for local_address, (send_bytes, recv_bytes) in sorted(ipv6_throughput.items(),
                                               key=lambda kv: sum(kv[1]),
                                               reverse=True):
 
-        ipv6_datapoints += "{measurement},{tag1}={val1},{tag2}={val2},{tag3}={val3},{tag4}={val4},{tag5}={val5} {field1}={field_val1},{field2}={field_val2} {timestamp}".format(
+        ipv6_datapoints += "{measurement},hostname={hostname},ip_version={ip_version},local_address={local_address},namespace={namespace},pod={pod} sent_bytes={send_bytes},received_bytes={received_bytes} {timestamp}".format(
             measurement=MEASUREMENT,
-            tag1="HOSTNAME",
-            val1=hostname,
-            tag2="IPv",
-            val2="6",
-            tag3="LADDR",
-            val3=k,
-            tag4="NAMESPACE",
-            val4=all_pod_metadata.get(k,["NA","NA"])[0],
-            tag5="POD",
-            val5=all_pod_metadata.get(k,["NA","NA"])[1],
-            field1=TX,
-            field_val1=int(send_bytes),
-            field2=RX,
-            field_val2=int(recv_bytes),
-            timestamp=int(float(time())*10**9))
+            hostname=hostname,
+            ip_version="6",
+            local_address=local_address,
+            namespace=all_pod_metadata.get(local_address, ["NA","NA"])[0],
+            pod=all_pod_metadata.get(local_address, ["NA","NA"])[1],
+            send_bytes=int(send_bytes),
+            received_bytes=int(recv_bytes),
+            timestamp=int(float(time())*10**9),
+        )
         ipv6_datapoints += "\n"
 
     response = requests.post(ENDPOINT, headers=HEADERS, data=ipv6_datapoints)

--- a/k8s-traffic-logger.py
+++ b/k8s-traffic-logger.py
@@ -179,8 +179,8 @@ b.attach_kretprobe(event="udpv6_recvmsg", fn_name="ret_udp_recvmsg")
 
 # influx DB line protocal tag/field names
 MEASUREMENT = "traffic"
-RX = "recv(-)"
-TX = "transmit(+)"
+RX = "received_bytes"
+TX = "sent_bytes"
 
 # output
 exiting = False

--- a/k8s-traffic-logger.py
+++ b/k8s-traffic-logger.py
@@ -140,10 +140,8 @@ int ret_udp_recvmsg(struct pt_regs *ctx)
 }
 """
 
-#pod name file
+# hostname file
 HOSTNAME_PATH="/etc/hostname"
-#namespace file
-NAMESPACE_PATH="/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
 def get_ipv4_key(k):
     return inet_ntop(AF_INET, pack("I", k.value))

--- a/k8s-traffic-logger.py
+++ b/k8s-traffic-logger.py
@@ -157,13 +157,11 @@ def get_ipv4_key(k):
 def get_ipv6_key(k):
     return inet_ntop(AF_INET6, k)
 
-def get_hostname():
-    hostname = ""
-    if os.path.isfile(HOSTNAME_PATH):
-        f = open(HOSTNAME_PATH)
-        hostname = f.read().strip()
-        f.close()
-    return hostname
+hostname = ""
+if os.path.isfile(HOSTNAME_PATH):
+    f = open(HOSTNAME_PATH)
+    hostname = f.read().strip()
+    f.close()
 
 # initialize BPF
 b = BPF(text=bpf_text)
@@ -183,7 +181,6 @@ b.attach_kretprobe(event="udpv6_recvmsg", fn_name="ret_udp_recvmsg")
 MEASUREMENT = "traffic"
 RX = "recv(-)"
 TX = "transmit(+)"
-hostname = get_hostname()
 
 # output
 exiting = False


### PR DESCRIPTION
Progress: see issue https://github.com/remram44/traffic-logger/issues/1

example output (tested on Polaris)

```bash
traffic,HOSTNAME=hsrn-vip10a-7e12,IPv=4,LADDR=192.168.50.5,NAMESPACE=c9s,POD=clabernetes-manager-79c88cd58f-wsg4p transmit(+)=1215,recv(-)=2563 1714070938111757824
traffic,HOSTNAME=hsrn-vip10a-7e12,IPv=4,LADDR=10.244.0.13,NAMESPACE=,POD= transmit(+)=117,recv(-)=2570 1714070938111800576
```